### PR TITLE
fix: send whatsapp template issue on crm app

### DIFF
--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -87,7 +87,7 @@ def last_message(doc, method):
         frappe.get_doc({
             "doctype": "WhatsApp Contact",
             "mobile_no": mobile_no,
-            "last_message": last_message,
+            "last_message": doc.message,
             "contact_name": mobile_no,
             "is_read": 0
         }).save()


### PR DESCRIPTION
### Title: 
Fix: TypeError when creating WhatsApp Contact due to incorrect assignment of function to last_message

### Bug Description
When sending a WhatsApp message to a new contact, the system encountered a psycopg2.ProgrammingError, which prevented the contact from being saved and the message from being processed correctly.

### Root Cause
The issue occurred because the last_message field in the new WhatsApp Contact document was incorrectly set to the last_message function reference instead of the actual message content (doc.message).

Steps to Reproduce:

Trigger a WhatsApp message to a mobile number not yet saved as a contact.

The last_message function is called during after_insert.

Error occurs on saving the new contact.

Actual/Observed Result:
psycopg2.ProgrammingError: can't adapt type 'function'

Expected Result:
New WhatsApp Contact should be created with the correct last message value.

### Fix Summary
Replaced the incorrect field assignment

### Affected Module
WhatsApp Chat Integration

### Linked Issue
None

### PR Reference
None
